### PR TITLE
 Update queries.rst

### DIFF
--- a/slick/src/sphinx/queries.rst
+++ b/slick/src/sphinx/queries.rst
@@ -40,7 +40,7 @@ are added through implicit conversions defined in
 the classes ``AnyExtensionMethods``, ``ColumnExtensionMethods``,
 ``NumericColumnExtensionMethods``, ``BooleanColumnExtensionMethods`` and
 ``StringColumnExtensionMethods``
-(cf. :slick:`ExtensionMethods <src/main/scala/slick/lifted/ExtensionMethods.scala>`).
+(cf. :slick:`ExtensionMethods <slick/src/main/scala/slick/lifted/ExtensionMethods.scala>`).
 
 .. warning::
    Most operators mimic the plain Scala equivalents, but you have to use ``===`` instead of


### PR DESCRIPTION
In Queries section,URL of ExtensionMethods.scala is not updated since version 3.0.0. When click on ExtensionMethods then it will show 404.
Link has been updated with latest github URL.
Incorrect URL => https://github.com/slick/slick/blob/3.1.1/src/main/scala/slick/lifted/ExtensionMethods.scala
Correct URL => https://github.com/slick/slick/blob/3.1.1/slick/src/main/scala/slick/lifted/ExtensionMethods.scala